### PR TITLE
Updating the plugin to take into account the holiday between July and September

### DIFF
--- a/assets/js/propertyhive-stamp-duty-calculator.js
+++ b/assets/js/propertyhive-stamp-duty-calculator.js
@@ -89,7 +89,6 @@ function ph_sdc_calculate() {
 
     if (
       !jQuery('#new_rates').is(':checked') &&
-      !jQuery('#new_rates_two').is(':checked') &&
       jQuery('#ftb').is(':checked') &&
       purchase_price <= 500000
     ) {

--- a/assets/js/propertyhive-stamp-duty-calculator.js
+++ b/assets/js/propertyhive-stamp-duty-calculator.js
@@ -1,121 +1,128 @@
-function ph_sdc_add_commas(nStr)
-{
-	nStr += '';
-	x = nStr.split('.');
-	x1 = x[0];
-	x2 = x.length > 1 ? '.' + x[1] : '';
-	var rgx = /(\d+)(\d{3})/;
-	while (rgx.test(x1)) {
-		x1 = x1.replace(rgx, '$1' + ',' + '$2');
-	}
-	return x1 + x2;
+function ph_sdc_add_commas(nStr) {
+  nStr += '';
+  x = nStr.split('.');
+  x1 = x[0];
+  x2 = x.length > 1 ? '.' + x[1] : '';
+  var rgx = /(\d+)(\d{3})/;
+  while (rgx.test(x1)) {
+    x1 = x1.replace(rgx, '$1' + ',' + '$2');
+  }
+  return x1 + x2;
 }
 
-function ph_sdc_calculate()
-{
-	var purchase_price = jQuery('.stamp-duty-calculator input[name=\'purchase_price\']').val().replace(/,/g, '');
+function ph_sdc_calculate() {
+  var purchase_price = jQuery(
+    ".stamp-duty-calculator input[name='purchase_price']"
+  )
+    .val()
+    .replace(/,/g, '');
 
-    if ( purchase_price != '' )
-    {
-        if ( jQuery('#new_rates').is(':checked') )
-        {
-            // Updated bands following changs on 8th July. Will run until 31st March
-            var bands = [
-                { min: 0, max: 500000, pct: 0 },
-                { min: 500000, max: 925000, pct: 0.05 },
-                { min: 925000, max: 1500000, pct: 0.1 },
-                { min: 1500000, max: null, pct: 0.12 }
-            ];
+  if (purchase_price != '') {
+    if (jQuery('#new_rates').is(':checked')) {
+      // Updated bands following changs on 8th July. Will run until 31st March
+      var bands = [
+        { min: 0, max: 500000, pct: 0 },
+        { min: 500000, max: 925000, pct: 0.05 },
+        { min: 925000, max: 1500000, pct: 0.1 },
+        { min: 1500000, max: null, pct: 0.12 },
+      ];
 
-            if ( jQuery('#btl_second').is(':checked') ) 
-            {
-                bands = [
-                    { min: 0, max: 500000, pct: 0.03 },
-                    { min: 500000, max: 925000, pct: 0.08 },
-                    { min: 925000, max: 1500000, pct: 0.13 },
-                    { min: 1500000, max: null, pct: 0.15 }
-                ];
-            }
-        }
-        else
-        {
-            var bands = [
-                { min: 0, max: 125000, pct: 0 },
-                { min: 125000, max: 250000, pct: 0.02 },
-                { min: 250000, max: 925000, pct: 0.05 },
-                { min: 925000, max: 1500000, pct: 0.1 },
-                { min: 1500000, max: null, pct: 0.12 }
-            ];
+      if (jQuery('#btl_second').is(':checked')) {
+        bands = [
+          { min: 0, max: 500000, pct: 0.03 },
+          { min: 500000, max: 925000, pct: 0.08 },
+          { min: 925000, max: 1500000, pct: 0.13 },
+          { min: 1500000, max: null, pct: 0.15 },
+        ];
+      }
+    } else if (jQuery('#new_rates_two').is(':checked')) {
+      // Updated bands following changes that run July - September
+      var bands = [
+        { min: 0, max: 250000, pct: 0 },
+        { min: 250000, max: 925000, pct: 0.05 },
+        { min: 925000, max: 1500000, pct: 0.1 },
+        { min: 1500000, max: null, pct: 0.12 },
+      ];
 
-            if ( jQuery('#btl_second').is(':checked') ) 
-            {
-                bands = [
-                    { min: 0, max: 125000, pct: 0.03 },
-                    { min: 125000, max: 250000, pct: 0.05 },
-                    { min: 250000, max: 925000, pct: 0.08 },
-                    { min: 925000, max: 1500000, pct: 0.13 },
-                    { min: 1500000, max: null, pct: 0.15 }
-                ];
-            }
-        }
-        
+      if (jQuery('#btl_second').is(':checked')) {
+        bands = [
+          { min: 0, max: 250000, pct: 0.03 },
+          { min: 250000, max: 925000, pct: 0.08 },
+          { min: 925000, max: 1500000, pct: 0.13 },
+          { min: 1500000, max: null, pct: 0.15 },
+        ];
+      }
+    } else {
+      var bands = [
+        { min: 0, max: 125000, pct: 0 },
+        { min: 125000, max: 250000, pct: 0.02 },
+        { min: 250000, max: 925000, pct: 0.05 },
+        { min: 925000, max: 1500000, pct: 0.1 },
+        { min: 1500000, max: null, pct: 0.12 },
+      ];
 
-        var number_bands = bands.length;
-        var total_tax = 0;
-
-        for (var i = 0; i < number_bands; ++i)
-        {
-            var band = bands[i];
-            var max = purchase_price;
-            if (band.max != null)
-            {
-                max = Math.min(band.max, max);
-            }
-            else
-            {
-
-            }
-            var taxable_sum = Math.max(0, max - band.min);
-            var tax = taxable_sum * band.pct;
-            total_tax += tax;
-        }
-
-        if ( !jQuery('#new_rates').is(':checked') && jQuery('#ftb').is(':checked') && purchase_price <= 500000 )
-        {
-            purchase_price = purchase_price - 300000;
-            purchase_price = Math.max(0, purchase_price);
-            total_tax = purchase_price * 0.05;
-        }
-
-        jQuery(".stamp-duty-calculator #results input[name=\'stamp_duty\']").val(ph_sdc_add_commas(total_tax.toFixed(2).replace(".00", "")));
-        
-        jQuery('.stamp-duty-calculator #results').slideDown();
+      if (jQuery('#btl_second').is(':checked')) {
+        bands = [
+          { min: 0, max: 125000, pct: 0.03 },
+          { min: 125000, max: 250000, pct: 0.05 },
+          { min: 250000, max: 925000, pct: 0.08 },
+          { min: 925000, max: 1500000, pct: 0.13 },
+          { min: 1500000, max: null, pct: 0.15 },
+        ];
+      }
     }
+
+    var number_bands = bands.length;
+    var total_tax = 0;
+
+    for (var i = 0; i < number_bands; ++i) {
+      var band = bands[i];
+      var max = purchase_price;
+      if (band.max != null) {
+        max = Math.min(band.max, max);
+      } else {
+      }
+      var taxable_sum = Math.max(0, max - band.min);
+      var tax = taxable_sum * band.pct;
+      total_tax += tax;
+    }
+
+    if (
+      !jQuery('#new_rates').is(':checked') &&
+      !jQuery('#new_rates_two').is(':checked') &&
+      jQuery('#ftb').is(':checked') &&
+      purchase_price <= 500000
+    ) {
+      purchase_price = purchase_price - 300000;
+      purchase_price = Math.max(0, purchase_price);
+      total_tax = purchase_price * 0.05;
+    }
+
+    jQuery(".stamp-duty-calculator #results input[name='stamp_duty']").val(
+      ph_sdc_add_commas(total_tax.toFixed(2).replace('.00', ''))
+    );
+
+    jQuery('.stamp-duty-calculator #results').slideDown();
+  }
 }
 
-jQuery(document).ready(function()
-{
-    jQuery("body").on('change', '#ftb', function() 
-    {
-        jQuery('#btl_second').attr('checked', false);
-    });
-    jQuery("body").on('change', '#btl_second', function() 
-    {
-        jQuery('#ftb').attr('checked', false);
-    });
+jQuery(document).ready(function () {
+  jQuery('body').on('change', '#ftb', function () {
+    jQuery('#btl_second').attr('checked', false);
+  });
+  jQuery('body').on('change', '#btl_second', function () {
+    jQuery('#ftb').attr('checked', false);
+  });
 
-	jQuery("body").on('blur', '.stamp-duty-calculator input', function() 
-	{
-		ph_sdc_calculate();
-	});
-    jQuery("body").on('change', '.stamp-duty-calculator input', function() 
-    {
-        ph_sdc_calculate();
-    });
-	jQuery("body").on('click', '.stamp-duty-calculator button', function() 
-	{
-		ph_sdc_calculate();
-	});
-
+  jQuery('body').on('blur', '.stamp-duty-calculator input', function () {
     ph_sdc_calculate();
+  });
+  jQuery('body').on('change', '.stamp-duty-calculator input', function () {
+    ph_sdc_calculate();
+  });
+  jQuery('body').on('click', '.stamp-duty-calculator button', function () {
+    ph_sdc_calculate();
+  });
+
+  ph_sdc_calculate();
 });

--- a/assets/js/propertyhive-stamp-duty-calculator.js
+++ b/assets/js/propertyhive-stamp-duty-calculator.js
@@ -35,6 +35,7 @@ function ph_sdc_calculate() {
           { min: 1500000, max: null, pct: 0.15 },
         ];
       }
+      //New conditional to take into account July-September holiday starts here
     } else if (jQuery('#new_rates_two').is(':checked')) {
       // Updated bands following changes that run July - September
       var bands = [

--- a/templates/stamp-duty-calculator.php
+++ b/templates/stamp-duty-calculator.php
@@ -4,6 +4,7 @@
     <input type="text" name="purchase_price" value="<?php echo $atts['price']; ?>" placeholder="e.g. 500,000">
 
     <label><input type="checkbox" name="new_rates" id="new_rates" value="1"> Property sale will complete on or before 30th of June 2021?</label>
+    <label><input type="checkbox" name="new_rates" id="new_rates_two" value="1"> Property sale will complete in July, August or September 2021?</label>
     <label><input type="checkbox" name="ftb" id="ftb" value="1"> I'm a first time buyer</label>
     <label><input type="checkbox" name="btl_second" id="btl_second" value="1"> Property is a buy-to-let or second home</label>
 


### PR DESCRIPTION
At the request of a client who's website I'm using this plugin on I have added an extra checkbox to the Stamp Duty Calculator form which allows users to select that they will be completing in July, August or September. 

In turn, I have updated the JS file for this form to take into account this new checkbox and to calculate the fees as per the rates which will be in place between the start of July and end of September.