### PR TITLE
Updated to account for July to September stamp duty relief in England

### DIFF
--- a/assets/js/propertyhive-stamp-duty-calculator.js
+++ b/assets/js/propertyhive-stamp-duty-calculator.js
@@ -19,40 +19,54 @@ function ph_sdc_calculate() {
 
   if (purchase_price != '') {
     if (jQuery('#new_rates').is(':checked')) {
-      // Updated bands following changs on 8th July. Will run until 31st March
-      var bands = [
-        { min: 0, max: 500000, pct: 0 },
-        { min: 500000, max: 925000, pct: 0.05 },
-        { min: 925000, max: 1500000, pct: 0.1 },
-        { min: 1500000, max: null, pct: 0.12 },
-      ];
+      // Updated bands following changes that last until end of
+     var bands = [
+       {
+         min: 0,
+         max: 250000,
+         pct: 0
+       },
+       {
+         min: 250000,
+         max: 925000,
+         pct: 0.05
+       },
+       {
+         min: 925000,
+         max: 1500000,
+         pct: 0.1
+       },
+       {
+         min: 1500000,
+         max: null,
+         pct: 0.12
+       },
+     ];
 
       if (jQuery('#btl_second').is(':checked')) {
-        bands = [
-          { min: 0, max: 500000, pct: 0.03 },
-          { min: 500000, max: 925000, pct: 0.08 },
-          { min: 925000, max: 1500000, pct: 0.13 },
-          { min: 1500000, max: null, pct: 0.15 },
+        bands = [{
+            min: 0,
+            max: 250000,
+            pct: 0.03
+          },
+          {
+            min: 250000,
+            max: 925000,
+            pct: 0.08
+          },
+          {
+            min: 925000,
+            max: 1500000,
+            pct: 0.13
+          },
+          {
+            min: 1500000,
+            max: null,
+            pct: 0.15
+          },
         ];
       }
       //New conditional to take into account July-September holiday starts here
-    } else if (jQuery('#new_rates_two').is(':checked')) {
-      // Updated bands following changes that run July - September
-      var bands = [
-        { min: 0, max: 250000, pct: 0 },
-        { min: 250000, max: 925000, pct: 0.05 },
-        { min: 925000, max: 1500000, pct: 0.1 },
-        { min: 1500000, max: null, pct: 0.12 },
-      ];
-
-      if (jQuery('#btl_second').is(':checked')) {
-        bands = [
-          { min: 0, max: 250000, pct: 0.03 },
-          { min: 250000, max: 925000, pct: 0.08 },
-          { min: 925000, max: 1500000, pct: 0.13 },
-          { min: 1500000, max: null, pct: 0.15 },
-        ];
-      }
     } else {
       var bands = [
         { min: 0, max: 125000, pct: 0 },
@@ -89,10 +103,11 @@ function ph_sdc_calculate() {
     }
 
     if (
-      !jQuery('#new_rates').is(':checked') &&
+      
       jQuery('#ftb').is(':checked') &&
       purchase_price <= 500000
     ) {
+      
       purchase_price = purchase_price - 300000;
       purchase_price = Math.max(0, purchase_price);
       total_tax = purchase_price * 0.05;

--- a/templates/stamp-duty-calculator.php
+++ b/templates/stamp-duty-calculator.php
@@ -3,8 +3,7 @@
     <label><?php echo __( 'Purchase Price', 'propertyhive' ); ?> (&pound;)</label>
     <input type="text" name="purchase_price" value="<?php echo $atts['price']; ?>" placeholder="e.g. 500,000">
 
-    <label><input type="checkbox" name="new_rates" id="new_rates" value="1"> Property sale will complete on or before 30th of June 2021?</label>
-    <label><input type="checkbox" name="new_rates" id="new_rates_two" value="1"> Property sale will complete on or between 1st of July and 30th of September 2021?</label>
+    <label><input type="checkbox" name="new_rates" id="new_rates" value="1"> Property sale will complete on or between 1st of July and 30th of September 2021?</label>
     <label><input type="checkbox" name="ftb" id="ftb" value="1"> I'm a first time buyer</label>
     <label><input type="checkbox" name="btl_second" id="btl_second" value="1"> Property is a buy-to-let or second home</label>
 


### PR DESCRIPTION
I've made some updates to remove the stamp duty relief button prior to the end of June and have updated it to work with the relief in place until the end of September accounting for the first time buyer amounts